### PR TITLE
Make source url configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,11 +5,13 @@
 class codimd (
   Hash[String,Data] $config,
   String            $version = 'master',
+  Stdlib::HTTPUrl   $source  = 'https://github.com/codimd/server.git',
 ) {
   include codimd::user
 
   class { 'codimd::install':
     version => $version,
+    source  => $source,
     require => Class['codimd::user'],
   }
   -> class { 'codimd::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,8 @@
 #
 # @api private
 class codimd::install (
-  String $version,
+  String          $version,
+  Stdlib::HTTPUrl $source,
 ) {
   assert_private()
 
@@ -21,7 +22,7 @@ class codimd::install (
     provider => 'git',
     user     => 'codimd',
     group    => 'codimd',
-    source   => 'https://github.com/codimd/server.git',
+    source   => $source,
     revision => $version,
   }
   ~> exec { '/opt/codimd/bin/setup':

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -13,6 +13,7 @@ describe 'codimd::install' do
           let(:params) do
             {
               version: 'master',
+              source: 'https://github.com/codimd/server.git',
             }
           end
 
@@ -46,6 +47,22 @@ describe 'codimd::install' do
               .with_user('codimd')
               .with_group('codimd')
               .with_refreshonly(true)
+          end
+        end
+
+        context 'with source => "https://gitlab.com/codimd/server.git"' do
+          let(:params) do
+            {
+              version: 'master',
+              source: 'https://gitlab.com/codimd/server.git',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it do
+            is_expected.to contain_vcsrepo('/opt/codimd')
+              .with_source('https://gitlab.com/codimd/server.git')
           end
         end
       end


### PR DESCRIPTION
We are using mirrored git repositories and therefore need to be able to select a different provider url.

I tested this basic change and was able to checkout the repository from a different git server.